### PR TITLE
GEMG-573: view on site

### DIFF
--- a/categories/admin.py
+++ b/categories/admin.py
@@ -4,12 +4,13 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 
 from .genericcollection import GenericCollectionTabularInline
-from .settings import RELATION_MODELS, JAVASCRIPT_URL, REGISTER_ADMIN
+from .settings import RELATION_MODELS, JAVASCRIPT_URL
 from .models import Category
 from .base import CategoryBaseAdminForm, CategoryBaseAdmin
 from .settings import MODEL_REGISTRY
 
 from categories import models as category_models
+
 
 class NullTreeNodeChoiceField(forms.ModelChoiceField):
     """A ModelChoiceField for tree nodes."""
@@ -22,8 +23,12 @@ class NullTreeNodeChoiceField(forms.ModelChoiceField):
         Creates labels which represent the tree level of each node when
         generating option labels.
         """
-        return u'%s %s' % (self.level_indicator * getattr(
-                                        obj, obj._mptt_meta.level_attr), obj)
+        return u'%s %s' % (
+            self.level_indicator * getattr(obj, obj._mptt_meta.level_attr),
+            obj
+        )
+
+
 if RELATION_MODELS:
     from .models import CategoryRelation
 
@@ -41,6 +46,7 @@ class CategoryAdminForm(CategoryBaseAdminForm):
         else:
             return self.cleaned_data['alternate_title']
 
+
 class CategorySponsorForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(CategorySponsorForm, self).__init__(*args, **kwargs)
@@ -56,6 +62,7 @@ class CategorySponsorInline(TabularInline):
     ordering = ('order',)
     raw_id_fields = ('sponsorship',)
     sortable_field_name = 'order'
+
 
 class SponsoredCategoryListFilter(admin.SimpleListFilter):
     title = u'Sponsored'
@@ -73,6 +80,7 @@ class SponsoredCategoryListFilter(admin.SimpleListFilter):
         if self.value() == 'unsponsored':
             return queryset.filter(is_sponsored=False)
         return queryset
+
 
 class CategoryAdmin(CategoryBaseAdmin):
     form = CategoryAdminForm
@@ -124,6 +132,7 @@ class CategoryAdmin(CategoryBaseAdmin):
         return obj.is_sponsored
     view_is_sponsored.boolean = True
     view_is_sponsored.short_description = u"is sponsored"
+
 
 admin.site.register(Category, CategoryAdmin)
 

--- a/categories/admin.py
+++ b/categories/admin.py
@@ -87,15 +87,20 @@ class CategoryAdmin(CategoryBaseAdmin):
     list_display = ('name', 'alternate_title', 'active', 'view_is_sponsored')
     fieldsets = (
         (None, {
-            'fields': ('parent', 'name', 'thumbnail', 'mobile_thumbnail', 'is_sponsored', 'active')
+            'fields': (
+                'parent', 'name', 'slug', 'site', 'is_sponsored', 'thumbnail',
+                'mobile_thumbnail', 'active',
+            )
         }),
         (_('Meta Data'), {
-            'fields': ('alternate_title', 'alternate_url', 'description',
-                        'meta_keywords', 'meta_extra'),
+            'fields': (
+                'alternate_title', 'alternate_url', 'description', 'meta_keywords',
+                'meta_extra'
+            ),
             'classes': ('grp-collapse',),
         }),
         (_('Advanced'), {
-            'fields': ('order', 'slug'),
+            'fields': ('order',),
             'classes': ('grp-collapse',),
         }),
     )

--- a/categories/base.py
+++ b/categories/base.py
@@ -3,9 +3,10 @@ This is the base class on which to build a hierarchical category-like model
 with customizable metadata and its own name space.
 """
 
-from django.contrib import admin
-from django.db import models
 from django import forms
+from django.contrib import admin
+from django.contrib.sites.models import Site
+from django.db import models
 from django.template.defaultfilters import slugify
 from django.utils.encoding import force_unicode
 from django.utils.translation import ugettext_lazy as _
@@ -51,6 +52,8 @@ class CategoryBase(MPTTModel):
         null=True,
         default=None,
         max_length=255)
+    # TODO: I would like to make this required if we can eliminate edge cases
+    site = models.ForeignKey(Site, blank=True, null=True)
 
     objects = CategoryManager()
     tree = TreeManager()

--- a/categories/models.py
+++ b/categories/models.py
@@ -8,14 +8,17 @@ from django.utils.encoding import force_unicode
 from django.utils.translation import ugettext_lazy as _
 
 from categories.base import CategoryBase
-from categories.settings import (RELATION_MODELS, RELATIONS, THUMBNAIL_UPLOAD_PATH,
-                        THUMBNAIL_STORAGE)
+from categories.settings import (
+    RELATION_MODELS, RELATIONS, THUMBNAIL_UPLOAD_PATH, THUMBNAIL_STORAGE
+)
 
 STORAGE = get_storage_class(THUMBNAIL_STORAGE)
+
 
 @transaction.commit_manually
 def flush_transaction():
     transaction.commit()
+
 
 class Category(CategoryBase):
     thumbnail = models.FileField(
@@ -53,19 +56,35 @@ class Category(CategoryBase):
         help_text="(Advanced) Any additional HTML to be placed verbatim "
                   "in the &lt;head&gt;")
     is_blog = models.BooleanField(default=False, blank=False, null=False)
-    show_converser_ad = models.BooleanField("Show a converser ad?", default=False,
-        help_text="Select to enable a converser ad for the category page. A 600x300 converser ad unit must be " \
-                  "active in Dart.")
+    show_converser_ad = models.BooleanField(
+        "Show a converser ad?",
+        default=False,
+        help_text=(
+            "Select to enable a converser ad for the category page. A 600x300 "
+            "converser ad unit must be active in Dart."
+        )
+    )
 
-    is_sponsored = models.BooleanField(default=False, blank=False, null=False,
-                                       help_text="This field is automatically marked as true if there are one or more sponsors assigned to this category. " \
-                                                 "It may also be manually marked true if there are no assigned sponsors.")
+    is_sponsored = models.BooleanField(
+        default=False,
+        blank=False,
+        null=False,
+        help_text=(
+            "This field is automatically marked as true if there are one or more "
+            "sponsors assigned to this category. It may also be manually marked true "
+            "if there are no assigned sponsors."
+        )
+    )
 
     sponsorships = models.ManyToManyField(
         "post_manager.ContentSponsorship",
         through="categories.CategorySponsor",
-        help_text="Adding a sponsor will automatically mark 'Is sponsored' as true. " \
-                  "Removing a sponsor or all sponsors will not affect the value of 'Is sponsored'.")
+        help_text=(
+            "Adding a sponsor will automatically mark 'Is sponsored' as true. "
+            "Removing a sponsor or all sponsors will not affect the value of "
+            "'Is sponsored'."
+        )
+    )
 
     @property
     def display_converser(self):
@@ -164,16 +183,19 @@ class CategoryRelation(models.Model):
         ContentType, limit_choices_to=CATEGORY_RELATION_LIMITS, verbose_name=_('content type'))
     object_id = models.PositiveIntegerField(verbose_name=_('object id'))
     content_object = generic.GenericForeignKey('content_type', 'object_id')
-    relation_type = models.CharField(verbose_name=_('relation type'),
+    relation_type = models.CharField(
+        verbose_name=_('relation type'),
         max_length="200",
         blank=True,
         null=True,
-        help_text=_("A generic text field to tag a relation, like 'leadphoto'."))
+        help_text=_("A generic text field to tag a relation, like 'leadphoto'.")
+    )
 
     objects = CategoryRelationManager()
 
     def __unicode__(self):
         return u"CategoryRelation"
+
 
 class CategorySponsor(models.Model):
     category = models.ForeignKey(Category)


### PR DESCRIPTION
- Added `site` FK field to Category
- Added `site` field to Category Detail page
- Moved `slug` field higher up on Category Detail page
- Updated `get_absolute_url` method to respect `site` field and use site-specific reverse

**Note: first commit is pep8 cleanup.  If you want to filter out the noise, only look at the second commit.**